### PR TITLE
Redeploy

### DIFF
--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,0 @@
-www.cloakpixel.com


### PR DESCRIPTION
Remove CNAME www.cloakpixel.com. Domain may not be paid for and access to site is being prevented.